### PR TITLE
OpenBSD & Fork Safety Changes

### DIFF
--- a/hotspot/src/os/bsd/vm/os_bsd.cpp
+++ b/hotspot/src/os/bsd/vm/os_bsd.cpp
@@ -2407,8 +2407,10 @@ static char* anon_mmap(char* requested_addr, size_t bytes, size_t alignment_hint
   if (fixed) {
     assert((uintptr_t)requested_addr % os::Bsd::page_size() == 0, "unaligned address");
     flags |= MAP_FIXED;
+#ifndef __OpenBSD__
   } else if (alignment_hint > 0) {
     flags |= MAP_ALIGNED(ffs(alignment_hint) - 1);
+#endif
   }
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we

--- a/jdk/src/share/native/java/lang/System.c
+++ b/jdk/src/share/native/java/lang/System.c
@@ -325,6 +325,10 @@ Java_java_lang_System_initProperties(JNIEnv *env, jclass cla, jobject props)
     }
 #endif
 
+#ifdef __OpenBSD__
+    PUTPROP(props, "java.net.preferIPv4Stack", sprops->java_net_preferIPv4Stack);
+#endif
+
     /* !!! DO NOT call PUTPROP_ForPlatformNString before this line !!!
      * !!! I18n properties have not been set up yet !!!
      */

--- a/jdk/src/share/native/java/lang/java_props.h
+++ b/jdk/src/share/native/java/lang/java_props.h
@@ -91,6 +91,9 @@ typedef struct {
 
     char *desktop;              /* Desktop name. */
 
+#ifdef __OpenBSD__
+    char *java_net_preferIPv4Stack; /* prefer IPv4 on OpenBSD. */
+#endif
 #ifdef MACOSX
     // These are for proxy-related information.
     // Note that if these platform-specific extensions get out of hand we should make a new

--- a/jdk/src/solaris/native/java/lang/childproc.c
+++ b/jdk/src/solaris/native/java/lang/childproc.c
@@ -62,7 +62,29 @@ isAsciiDigit(char c)
   return c >= '0' && c <= '9';
 }
 
-#ifdef _ALLBSD_SOURCE
+#if defined(_ALLBSD_SOURCE) && !defined(MACOSX)
+/*
+ * Quoting POSIX: "If a multi-threaded process calls fork(), the new
+ * process shall contain a replica of the calling thread and its entire
+ * address space, possibly including the states of mutexes and other
+ * resources. Consequently, to avoid errors, the child process may only
+ * execute async-signal-safe operations until such time as one of the exec
+ * functions is called."
+ *
+ * opendir and readir are not async-signal-safe and can deadlock when
+ * called after fork or vfork (and before exec) so use closefrom syscall
+ * which is safe to call after forking.
+ */
+int
+closeDescriptors(void)
+{
+    int err;
+    RESTARTABLE(closefrom(FAIL_FILENO + 1), err);
+    return err;
+}
+#else
+
+#ifdef MACOSX
 #define FD_DIR "/dev/fd"
 #define dirent64 dirent
 #define readdir64 readdir
@@ -113,6 +135,7 @@ closeDescriptors(void)
 
     return 1;
 }
+#endif /* defined(_ALLBSD_SOURCE) && !defined(MACOSX) */
 
 int
 moveDescriptor(int fd_from, int fd_to)

--- a/jdk/src/solaris/native/java/lang/java_props_md.c
+++ b/jdk/src/solaris/native/java/lang/java_props_md.c
@@ -431,6 +431,10 @@ GetJavaProperties(JNIEnv *env)
     sprops.awt_toolkit = "sun.awt.X11.XToolkit";
 #endif
 
+#ifdef __OpenBSD__
+    sprops.java_net_preferIPv4Stack = "true";
+#endif
+
     /* This is used only for debugging of font problems. */
     v = getenv("JAVA2D_FONTPATH");
     sprops.font_dir = v ? v : NULL;


### PR DESCRIPTION
Three changes to do the following:
* fix build on OpenBSD (no MAP_ALIGNED for mmap)
* port closefrom(2) change from jdk11u
* Set IPv4 as the preferred stack due to lack of support for IPv4-mapped IPv6 sockets - OpenBSD only