### PR TITLE
Corrections for fork safety on BSD:

### DIFF
--- a/jdk/src/solaris/native/java/lang/childproc.c
+++ b/jdk/src/solaris/native/java/lang/childproc.c
@@ -78,9 +78,13 @@ isAsciiDigit(char c)
 int
 closeDescriptors(void)
 {
+#if defined(__FreeBSD__)
+    closefrom(FAIL_FILENO + 1);
+#else
     int err;
     RESTARTABLE(closefrom(FAIL_FILENO + 1), err);
-    return err;
+#endif
+    return 1;
 }
 #else
 


### PR DESCRIPTION
* Fix closeDescriptors() return value
* Fix closefrom(2) call on FreeBSD