### PR TITLE
Clang10+fixes

### DIFF
--- a/hotspot/make/bsd/makefiles/gcc.make
+++ b/hotspot/make/bsd/makefiles/gcc.make
@@ -149,7 +149,12 @@ ifeq ($(USE_CLANG), true)
     PCH_FLAG/sharedRuntimeTrig.o = $(PCH_FLAG/NO_PCH)
     PCH_FLAG/sharedRuntimeTrans.o = $(PCH_FLAG/NO_PCH)
     PCH_FLAG/unsafe.o = $(PCH_FLAG/NO_PCH)
-  
+
+    ifeq ($(shell expr $(CC_VER_MAJOR) = 10 \| $(CC_VER_MAJOR) = 11), 1)
+      ifeq ($(BUILDARCH), i486)
+        PCH_FLAG/bitMap.o = $(PCH_FLAG/NO_PCH)
+      endif
+    endif
   endif
 else # ($(USE_CLANG), true)
   # check for precompiled headers support
@@ -336,6 +341,11 @@ ifeq ($(USE_CLANG), true)
   endif
   ifeq ($(shell expr $(CC_VER_MAJOR) = 6 \& $(CC_VER_MINOR) = 0), 1)
     OPT_CFLAGS/unsafe.o += -O1
+  endif
+  ifeq ($(shell expr $(CC_VER_MAJOR) = 10 \| $(CC_VER_MAJOR) = 11), 1)
+    ifeq ($(BUILDARCH), i486)
+      OPT_CFLAGS/bitMap.o += -O1
+    endif
   endif
 else
   # 6835796. Problem in GCC 4.3.0 with mulnode.o optimized compilation.

--- a/hotspot/make/bsd/makefiles/gcc.make
+++ b/hotspot/make/bsd/makefiles/gcc.make
@@ -145,11 +145,16 @@ ifeq ($(USE_CLANG), true)
     # level specific PCH files for the opt build and use them here, but
     # it's probably not worth the effort as long as only a few files
     # need this special handling.
-    PCH_FLAG/loopTransform.o = $(PCH_FLAG/NO_PCH)
     PCH_FLAG/sharedRuntimeTrig.o = $(PCH_FLAG/NO_PCH)
     PCH_FLAG/sharedRuntimeTrans.o = $(PCH_FLAG/NO_PCH)
-    PCH_FLAG/unsafe.o = $(PCH_FLAG/NO_PCH)
 
+    ifeq ($(shell expr $(CC_VER_MAJOR) = 4 \& $(CC_VER_MINOR) = 2), 1)
+      PCH_FLAG/loopTransform.o = $(PCH_FLAG/NO_PCH)
+      PCH_FLAG/unsafe.o = $(PCH_FLAG/NO_PCH)
+    endif
+    ifeq ($(shell expr $(CC_VER_MAJOR) = 6 \& $(CC_VER_MINOR) = 0), 1)
+      PCH_FLAG/unsafe.o = $(PCH_FLAG/NO_PCH)
+    endif
     ifeq ($(shell expr $(CC_VER_MAJOR) = 10 \| $(CC_VER_MAJOR) = 11), 1)
       ifeq ($(BUILDARCH), i486)
         PCH_FLAG/bitMap.o = $(PCH_FLAG/NO_PCH)

--- a/hotspot/src/share/vm/runtime/sharedRuntime.cpp
+++ b/hotspot/src/share/vm/runtime/sharedRuntime.cpp
@@ -2630,7 +2630,7 @@ void AdapterHandlerLibrary::create_native_wrapper(methodHandle method) {
     if (buf != NULL) {
       CodeBuffer buffer(buf);
       double locs_buf[20];
-      buffer.insts()->initialize_shared_locs((relocInfo*)locs_buf, sizeof(locs_buf) / sizeof(relocInfo));
+      buffer.insts()->initialize_shared_locs((relocInfo*)locs_buf, sizeof(locs_buf) / (sizeof(relocInfo)));
       MacroAssembler _masm(&buffer);
 
       // Fill in the signature array, for the calling-convention call.
@@ -2733,7 +2733,7 @@ nmethod *AdapterHandlerLibrary::create_dtrace_nmethod(methodHandle method) {
       // Need a few relocation entries
       double locs_buf[20];
       buffer.insts()->initialize_shared_locs(
-        (relocInfo*)locs_buf, sizeof(locs_buf) / sizeof(relocInfo));
+        (relocInfo*)locs_buf, sizeof(locs_buf) / (sizeof(relocInfo)));
       MacroAssembler _masm(&buffer);
 
       // Generate the compiled-to-native wrapper code


### PR DESCRIPTION
* Fix fastdebug build with clang 10+ by suppressing some warnings.
* Reduce optimization level of bitMap.cpp to -O1 to fix an undefined symbol runtime linking error with clang 10 & 11 on i386. This should fix this issue that I also ran into on OpenBSD with clang 10.0.1 on i386:
https://lists.freebsd.org/pipermail/freebsd-java/2020-October/013348.html
* Only disable pre-compiled header use for loopTransform.cpp and unsafe.cpp when the optimization level has been reduced for them. This is just a cleanup that syncs the disabling of pre-compiled headers with the same conditions for when the optimization level was reduced to work-around clang bugs.
