### PR TITLE
Fixes for arm32 on FreeBSD.

### DIFF
--- a/hotspot/src/os/bsd/vm/os_perf_bsd.cpp
+++ b/hotspot/src/os/bsd/vm/os_perf_bsd.cpp
@@ -43,6 +43,15 @@
   #include <mach/task_info.h>
 #else
   #ifndef __NetBSD__
+    #ifdef __FreeBSD__
+      /*
+       * Older versions of FreeBSD accidentally include machine/frame.h from
+       * sys/user.h header. Disable this bad behavior, because a
+       * 'non-standard' structure 'frame' conflict with an internal structure
+       * with the same name.
+       */
+      #define _MACHINE_PCB_H_
+    #endif
     #include <sys/user.h>
   #endif
   #include <sys/sched.h>

--- a/hotspot/src/os_cpu/bsd_zero/vm/os_bsd_zero.cpp
+++ b/hotspot/src/os_cpu/bsd_zero/vm/os_bsd_zero.cpp
@@ -450,7 +450,7 @@ extern "C" {
 // Implementations of atomic operations not supported by processors.
 //  -- http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Atomic-Builtins.html
 
-#ifndef _LP64
+#if !defined(_LP64) && !__has_builtin(__sync_val_compare_and_swap_8)
 extern "C" {
   long long unsigned int __sync_val_compare_and_swap_8(
     volatile void *ptr,


### PR DESCRIPTION
This patch allows compile openjdk8 on current FreeBSD for 32-bit arm.